### PR TITLE
Remove NodeJS 7 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - 8
-  - 7
 install:
   - yarn install
   - yarn global add nyc


### PR DESCRIPTION
Looking at the build log error, yarn doesn't support NodeJS 7 but does support anything 8 & upwards.
Sounds like removing support for 7 could be a possible fix for this.